### PR TITLE
Fix path in test for deps.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Arpack"
 uuid = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"
-version = "v0.1.1"
+version = "v0.1.3"
 
 [deps]
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"

--- a/src/Arpack.jl
+++ b/src/Arpack.jl
@@ -7,8 +7,10 @@ Arnoldi and Lanczos iteration for computing eigenvalues
 """
 module Arpack
 
-if isfile("../deps/deps.jl")
-    include("../deps/deps.jl")
+const depsfile = joinpath(@__DIR__, "..", "deps", "deps.jl")
+
+if isfile(depsfile)
+    include(depsfile)
 else
     throw(ErrorException("""
 No deps.jl file could be found. Please try running Pkg.build("Arpack").


### PR DESCRIPTION
So `"../deps/deps.jl"`, of course, has a different meaning depending on whether it is used in `include` or `isfile`. However, the tests are run from within the `test` directory so this wasn't caught by CI.

Fixed #21.