### PR TITLE
Account for sign of singular vectors in svds, fixes #41

### DIFF
--- a/src/Arpack.jl
+++ b/src/Arpack.jl
@@ -312,7 +312,7 @@ julia> s.S
 svds(A; kwargs...) = _svds(A; kwargs...)
 function _orth!(P)
     Q,R = qr!(P)
-    return Matrix(Q) * Diagonal(sign.(diag(R)))
+    return Matrix(Q) * Diagonal(flipsign.(one(eltype(R)),diag(R)))
 end
 function _svds(X; nsv::Int = 6, ritzvec::Bool = true, tol::Float64 = 0.0, maxiter::Int = 1000, ncv::Int = 2*nsv, v0::Vector=zeros(eltype(X),(0,)))
     if nsv < 1

--- a/src/Arpack.jl
+++ b/src/Arpack.jl
@@ -310,8 +310,8 @@ julia> s.S
     that the size is smallest.
 """
 svds(A; kwargs...) = _svds(A; kwargs...)
-function _orth!(Q)
-    Q,R = qr!(Q)
+function _orth!(P)
+    Q,R = qr!(P)
     return Matrix(Q) * Diagonal(sign.(diag(R)))
 end
 function _svds(X; nsv::Int = 6, ritzvec::Bool = true, tol::Float64 = 0.0, maxiter::Int = 1000, ncv::Int = 2*nsv, v0::Vector=zeros(eltype(X),(0,)))

--- a/src/Arpack.jl
+++ b/src/Arpack.jl
@@ -312,7 +312,8 @@ julia> s.S
 svds(A; kwargs...) = _svds(A; kwargs...)
 function _orth!(P)
     Q,R = qr!(P)
-    return Matrix(Q) * Diagonal(flipsign.(one(eltype(R)),diag(R)))
+    rsign = [iszero(rval) ? one(rval) : sign(rval) for rval in diag(R)]
+    return Matrix(Q) * Diagonal(rsign)
 end
 function _svds(X; nsv::Int = 6, ritzvec::Bool = true, tol::Float64 = 0.0, maxiter::Int = 1000, ncv::Int = 2*nsv, v0::Vector=zeros(eltype(X),(0,)))
     if nsv < 1


### PR DESCRIPTION
Introduces a function `_orth!` to orthonormalize singular vectors using `qr!`. Should fix #41. :)

A couple items I'm not sure of:
+ should the sign check incorporate more than the diagonal of `R`?
+ seems like we could be more memory efficient by doing the sign flip in-place (I think it currently allocates a new matrix), any suggestions on what to do?

This is my first PR (yay!), apologies in advance if I've done any of this the wrong way.