### PR TITLE
Attempt to work around problems like #55 using symlink magic

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -138,7 +138,7 @@ if unsatisfied || !isinstalled(dl_info...; prefix=prefix)
         @warn(strip(replace(
         """
         Attempting to symlink \"$(sym_file)\" => \"$(blaslib)\"; if this fails, try running it
-        manually with super user permissions via: sudod ln -s $(blaslib) $(sym_file)
+        manually with super user permissions via: sudo ln -s $(blaslib) $(sym_file)
         """, '\n' => ' ')))
         symlink(blaslib, sym_file)
     end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -132,7 +132,7 @@ if unsatisfied || !isinstalled(dl_info...; prefix=prefix)
         We will attempt to automatically map the distribution-provided BLAS library to such
         that libarpack can find it, but this may not work.  If issues with Arpack.jl persist,
         we recommend using the Julia binaries available for download from the official website
-        at https://julialang.org/downloads.html
+        at https://julialang.org/downloads/
         """, '\n' => ' ')))
 
         @warn(strip(replace(

--- a/deps/get_default_blaslib_names.jl
+++ b/deps/get_default_blaslib_names.jl
@@ -1,0 +1,40 @@
+using BinaryProvider
+
+# Snarf download_info from `build.jl`
+m = Module(:__anon__)
+Core.eval(m, quote
+	using BinaryProvider
+	function write_deps_file(args...; kwargs...); end
+    function install(args...; kwargs...); end
+	ARGS = ["."]
+end)
+include_string(m, String(read("build.jl")))
+download_info = Core.eval(m, :(download_info))
+
+try
+    mkdir("downloads")
+catch
+end
+
+# Download them all!
+for key in keys(download_info)
+    download_verify_unpack(
+        download_info[key][1],
+        download_info[key][2],
+        joinpath(@__DIR__, "downloads", triplet(key));
+        tarball_path=joinpath(@__DIR__, "downloads", triplet(key)*".tar.gz"),
+    )
+end
+
+# Get linkage name of openblas for everybody
+using ObjectFile
+println("default_blaslib_names = Dict(")
+for p in keys(download_info)
+    libarpack = LibraryProduct(Prefix(joinpath(@__DIR__, "downloads", triplet(p))), "libarpack", :libarpack)
+    libarpack_path = locate(libarpack; platform=p)
+    blas_name = readmeta(libarpack_path) do oh
+        blaslibs = filter(x -> occursin("blas", x), [path(l) for l in DynamicLinks(oh)])
+        println("    $(repr(p)) => $(repr(basename(first(blaslibs)))),")
+    end
+end
+println(")")


### PR DESCRIPTION
We should be able to create symlinks to the non-default-named BLAS libraries automatically.  This does this, as a stopgap solution until we have more control over the runtime linker.