### PR TITLE
Add manual build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,33 @@
 [![][docs-stable-img]][docs-stable-url]
 [![][docs-latest-img]][docs-latest-url]
 
+Julia wrapper for the [arpack](https://github.com/opencollab/arpack-ng/) library
+designed to solve large scale eigenvalue problems.
+
+## Installation
+
+You can install Arpack.jl through the Julia package manager:
+```julia
+julia> Pkg.add("Arpack")
+```
+
+Arpack.jl will use [BinaryProvider.jl](https://github.com/JuliaPackaging/BinaryProvider.jl)
+to automatically install the Arpack binaries.
+
+## Custom Installation
+
 If you get
 ```
 ERROR: LoadError: LibraryProduct(nothing, ["libarpack"], :libarpack, "Prefix(~/.julia/packages/Arpack/cu5By/deps/usr)") is not satisfied, cannot generate deps.jl!
 ```
-when building Arpack, download the source of the [v3.5.0 of arpack-ng](https://github.com/opencollab/arpack-ng/releases/tag/3.5.0),
-extract it in some `<directory>`, build it and do
+when building Arpack, it may be because your Julia installation uses your system
+blas for which the symbols are not suffixed by `_64_` while this is required by
+the compiled binaries provided by [BinaryProvider.jl](https://github.com/JuliaPackaging/BinaryProvider.jl).
+This is notably the case on [ArchLinux](https://www.archlinux.org/).
+In these case, compile binaries that do not require this suffix as follows.
+Download the source of the [v3.5.0 of arpack-ng](https://github.com/opencollab/arpack-ng/releases/tag/3.5.0),
+extract it in some `<directory>`, build it and do (note that you may need to
+update `cu6By` to match the one printed in the error message printed above).
 ```
 $ cp <directory>/arpack-ng-3.5.0/SRC/.libs/libarpack.so.2.0.0 ~/.julia/packages/Arpack/cu5By/deps/usr/lib/
 $ julia -e 'import Pkg; Pkg.build("Arpack")'

--- a/README.md
+++ b/README.md
@@ -7,6 +7,18 @@
 [![][docs-stable-img]][docs-stable-url]
 [![][docs-latest-img]][docs-latest-url]
 
+If you get
+```
+ERROR: LoadError: LibraryProduct(nothing, ["libarpack"], :libarpack, "Prefix(~/.julia/packages/Arpack/cu5By/deps/usr)") is not satisfied, cannot generate deps.jl!
+```
+when building Arpack, download the source of the [v3.5.0 of arpack-ng](https://github.com/opencollab/arpack-ng/releases/tag/3.5.0),
+extract it in some `<directory>`, build it and do
+```
+$ cp <directory>/arpack-ng-3.5.0/SRC/.libs/libarpack.so.2.0.0 ~/.julia/packages/Arpack/cu5By/deps/usr/lib/
+$ julia -e 'import Pkg; Pkg.build("Arpack")'
+  Building Arpack → `~/.julia/packages/Arpack/UiiMc/deps/build.log`
+```
+
 [docs-latest-img]: https://img.shields.io/badge/docs-latest-blue.svg
 [docs-latest-url]: http://JuliaLinearAlgebra.github.io/Arpack.jl/latest/
 


### PR DESCRIPTION
Add instructions on how to link to a manual installation of the library.
It may help with https://github.com/JuliaLinearAlgebra/Arpack.jl/issues/5 which is still an issue for ArchLinux and the method mentioned in the ArchLinux wiki is incorrect as detailed in https://github.com/JuliaLinearAlgebra/Arpack.jl/issues/5#issuecomment-470523795