### PR TITLE
travis arm64 allow failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,17 @@ notifications:
 git:
   depth: 99999999
 
+arch:
+  - amd64
+  - arm64
+
+matrix:
+  allow_failures:
+    - arch: arm64
+
+jobs:
+  fast_finish: true
+
 after_success:
   # push coverage results to Coveralls and Codecov
   - julia -e 'cd(Pkg.dir("Arpack")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder()); Codecov.submit(Codecov.process_folder())'


### PR DESCRIPTION
Arpack fails on ARM64, discovered downstream with desire to run packages like IncrementalInference.jl on a RaspberryPi -- which depends on Arpack.  Will try contribute here at some point, but wanted to extend the Travis tests so long.