### PR TITLE
fix issue#85 Add an operating mode where INFO = 1 is not an error

### DIFF
--- a/src/Arpack.jl
+++ b/src/Arpack.jl
@@ -18,7 +18,7 @@ include("libarpack.jl")
 
 ## eigs
 """
-    eigs(A; nev=6, ncv=max(20,2*nev+1), which=:LM, tol=0.0, maxiter=300, sigma=nothing, ritzvec=true, explicittransform=:auto, v0=zeros((0,)), check=true) -> (d,[v,],nconv,niter,nmult,resid)
+    eigs(A; nev=6, ncv=max(20,2*nev+1), which=:LM, tol=0.0, maxiter=300, sigma=nothing, ritzvec=true, explicittransform=:auto, v0=zeros((0,)), check=0) -> (d,[v,],nconv,niter,nmult,resid)
 
 Computes eigenvalues `d` of `A` using implicitly restarted Lanczos or Arnoldi iterations for real symmetric or
 general nonsymmetric matrices respectively. See [the manual](@ref man-eigs) for more information.
@@ -29,8 +29,9 @@ iterations `niter` and the number of matrix vector multiplications `nmult`, as w
 final residual vector `resid`. The parameter `explicittransform` takes the values `:auto`, `:none`
 or `:shiftinvert`, specifying if shift and invert should be explicitly invoked in julia code.
 
-When `check = true`, an error is thrown if maximum number of iterations taken (`info = 1`). This usually means all possible eigenvalues has been found according to ARPACK manual.
-When `check = false`, return currently converged eigenvalues when `info = 1`. Only a `@warn` will given.
+When `check = 0`, an error is thrown if maximum number of iterations taken (`info = 1`). This usually means all possible eigenvalues has been found according to ARPACK manual.
+When `check = 1`, return currently converged eigenvalues when `info = 1`. And a `@warn` will given.
+When `check = 2`, return currently converged eigenvalues when `info = 1`.
 
 # Examples
 ```jldoctest
@@ -62,18 +63,19 @@ function eigs(A::AbstractMatrix, B::AbstractMatrix; kwargs...)
     eigs(convert(AbstractMatrix{Tnew}, A), convert(AbstractMatrix{Tnew}, B); kwargs...)
 end
 """
-    eigs(A, B; nev=6, ncv=max(20,2*nev+1), which=:LM, tol=0.0, maxiter=300, sigma=nothing, ritzvec=true, v0=zeros((0,)), check=true) -> (d,[v,],nconv,niter,nmult,resid)
+    eigs(A, B; nev=6, ncv=max(20,2*nev+1), which=:LM, tol=0.0, maxiter=300, sigma=nothing, ritzvec=true, v0=zeros((0,)), check=0) -> (d,[v,],nconv,niter,nmult,resid)
 
 Computes generalized eigenvalues `d` of `A` and `B` using implicitly restarted Lanczos or Arnoldi iterations for real symmetric or general nonsymmetric matrices respectively. See [the manual](@ref man-eigsgen) for more information.
 
-When `check = true`, an error is thrown if maximum number of iterations taken (`info = 1`). This usually means all possible eigenvalues has been found according to ARPACK manual.
-When `check = false`, return currently converged eigenvalues when `info = 1`. Only a `@warn` will given.
+When `check = 0`, an error is thrown if maximum number of iterations taken (`info = 1`). This usually means all possible eigenvalues has been found according to ARPACK manual.
+When `check = 1`, return currently converged eigenvalues when `info = 1`. And a `@warn` will given.
+When `check = 2`, return currently converged eigenvalues when `info = 1`.
 """
 eigs(A, B; kwargs...) = _eigs(A, B; kwargs...)
 function _eigs(A, B;
                nev::Integer=6, ncv::Integer=max(20,2*nev+1), which=:LM,
                tol=0.0, maxiter::Integer=300, sigma=nothing, v0::Vector=zeros(eltype(A),(0,)),
-               ritzvec::Bool=true, explicittransform::Symbol=:auto, check::Bool=true)
+               ritzvec::Bool=true, explicittransform::Symbol=:auto, check::Integer=0)
     n = checksquare(A)
 
     eigval_postprocess = false; # If we need to shift-and-invert eigvals as postprocessing
@@ -241,8 +243,8 @@ function _eigs(A, B;
     (resid, v, ldv, iparam, ipntr, workd, workl, lworkl, rwork, TOL) =
         aupd_wrapper(T, matvecA!, matvecB, solveSI, n, sym, iscmplx, bmat, nev, ncv, whichstr, tol, maxiter, mode, v0, check)
     # Postprocessing to get eigenvalues and eigenvectors
-    !check && (iparam[5] < nev) && @warn "nev = $nev, but only $(iparam[5]) found!"
-    output = eupd_wrapper(T, n, sym, iscmplx, bmat, check ? nev : iparam[5], whichstr, ritzvec, TOL,
+    check == 1 && (iparam[5] < nev) && @warn "nev = $nev, but only $(iparam[5]) found!"
+    output = eupd_wrapper(T, n, sym, iscmplx, bmat, check == 0 ? nev : iparam[5], whichstr, ritzvec, TOL,
                           resid, ncv, v, ldv, sigma, iparam, ipntr, workd, workl, lworkl, rwork)
 
     # Issue 10495, 10701: Check that all eigenvalues are converged
@@ -312,13 +314,14 @@ function svds(A::AbstractMatrix{T}; kwargs...) where T
 end
 
 """
-    svds(A; nsv=6, ritzvec=true, tol=0.0, maxiter=1000, ncv=2*nsv, v0=zeros((0,))) -> (SVD([left_sv,] s, [right_sv,]), nconv, niter, nmult, resid, check=true)
+    svds(A; nsv=6, ritzvec=true, tol=0.0, maxiter=1000, ncv=2*nsv, v0=zeros((0,))) -> (SVD([left_sv,] s, [right_sv,]), nconv, niter, nmult, resid, check=0)
 
 Computes the largest singular values `s` of `A` using implicitly restarted Lanczos
 iterations derived from [`eigs`](@ref). See [the manual](@ref man-svds) for more information.
 
-When `check = true`, an error is thrown if maximum number of iterations taken (`info = 1`). This usually means all possible eigenvalues has been found according to ARPACK manual.
-When `check = false`, return currently converged eigenvalues when `info = 1`. Only a `@warn` will given.
+When `check = 0`, an error is thrown if maximum number of iterations taken (`info = 1`). This usually means all possible eigenvalues has been found according to ARPACK manual.
+When `check = 1`, return currently converged eigenvalues when `info = 1`. And a `@warn` will given.
+When `check = 2`, return currently converged eigenvalues when `info = 1`.
 """
 svds(A; kwargs...) = _svds(A; kwargs...)
 function _orth!(P)
@@ -327,7 +330,7 @@ function _orth!(P)
     rsign = [_sign(R[i,i]) for i in 1:size(R,2)]
     return rmul!(Matrix(Q), Diagonal(rsign))
 end
-function _svds(X; nsv::Int = 6, ritzvec::Bool = true, tol::Float64 = 0.0, maxiter::Int = 1000, ncv::Int = 2*nsv, v0::Vector=zeros(eltype(X),(0,)), check::Bool=true)
+function _svds(X; nsv::Int = 6, ritzvec::Bool = true, tol::Float64 = 0.0, maxiter::Int = 1000, ncv::Int = 2*nsv, v0::Vector=zeros(eltype(X),(0,)), check::Integer=0)
     if nsv < 1
         throw(ArgumentError("number of singular values (nsv) must be ≥ 1, got $nsv"))
     end
@@ -340,6 +343,7 @@ function _svds(X; nsv::Int = 6, ritzvec::Bool = true, tol::Float64 = 0.0, maxite
         throw(DimensionMismatch("length of v0, the guess for the starting right Krylov vector, must be 0, or $n, got $(length(v0))"))
     end
     ex    = eigs(AtA_or_AAt(X), I; which = :LM, ritzvec = ritzvec, nev = nsv, tol = tol, maxiter = maxiter, v0=v0, check=check)
+    check != 0 && (nsv = length(ex[1]))
     # ind   = [1:2:ncv;]
     # sval  = abs.(ex[1][ind])
 

--- a/src/libarpack.jl
+++ b/src/libarpack.jl
@@ -50,7 +50,7 @@ end
 function aupd_wrapper(T, matvecA!::Function, matvecB::Function, solveSI::Function, n::Integer,
                       sym::Bool, cmplx::Bool, bmat,
                       nev::Integer, ncv::Integer, which,
-                      tol::Real, maxiter::Integer, mode::Integer, v0::Vector)
+                      tol::Real, maxiter::Integer, mode::Integer, v0::Vector, check::Bool)
     lworkl = cmplx ? ncv * (3*ncv + 5) : (sym ? ncv * (ncv + 8) :  ncv * (3*ncv + 6) )
     TR = cmplx ? T.types[1] : T
     TOL = Ref{TR}(tol)
@@ -89,6 +89,9 @@ function aupd_wrapper(T, matvecA!::Function, matvecB::Function, solveSI::Functio
                   iparam, ipntr, workd, workl, lworkl, info)
         end
         if info[] != 0
+            if info[] == 1 && !check
+                return (resid, v, n, iparam, ipntr, workd, workl, lworkl, rwork, TOL)
+            end
             throw(XYAUPD_Exception(info[]))
         end
 

--- a/src/libarpack.jl
+++ b/src/libarpack.jl
@@ -50,7 +50,7 @@ end
 function aupd_wrapper(T, matvecA!::Function, matvecB::Function, solveSI::Function, n::Integer,
                       sym::Bool, cmplx::Bool, bmat,
                       nev::Integer, ncv::Integer, which,
-                      tol::Real, maxiter::Integer, mode::Integer, v0::Vector, check::Bool)
+                      tol::Real, maxiter::Integer, mode::Integer, v0::Vector, check::Integer)
     lworkl = cmplx ? ncv * (3*ncv + 5) : (sym ? ncv * (ncv + 8) :  ncv * (3*ncv + 6) )
     TR = cmplx ? T.types[1] : T
     TOL = Ref{TR}(tol)
@@ -89,7 +89,7 @@ function aupd_wrapper(T, matvecA!::Function, matvecB::Function, solveSI::Functio
                   iparam, ipntr, workd, workl, lworkl, info)
         end
         if info[] != 0
-            if info[] == 1 && !check
+            if info[] == 1 && check != 0
                 return (resid, v, n, iparam, ipntr, workd, workl, lworkl, rwork, TOL)
             end
             throw(XYAUPD_Exception(info[]))


### PR DESCRIPTION
When `maxiter` reached in ARPACK routine, parameter `info` will be set to 1. This is means "Maximum number of iterations taken. All possible eigenvalues of `OP` has been found. `IPARAM(5)` return the number of wanted converged Ritz values." according to ARPACK manual [here](https://www.caam.rice.edu/software/ARPACK/UG/node137.html#SECTION001220000000000000000). But current vertion of `Arpack.jl` will just throw a `XYEUPD_Expection` without a way to get currently converged eigenvalues and eigenvectors as scipy does ([scipy manual)](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.eigs.html).

i add a parameter `check::Integer=0` to both `eigs` and `svds`. `check==0` means current `Arpack.jl` behavier; `check==1` means return currently converged ones with a `@warn` poping up; so as `check==2` but without a warning. Because of the suggestions [here](https://docs.julialang.org/en/v1/manual/style-guide/#Don't-overuse-try-catch),  donot using a `Exception` like scipy do. 